### PR TITLE
v2.5.0: Memwright, Org Secrets, VectorBoost, pricing update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-04-07
+
+### Added - Shared Conversational Memory (Memwright)
+- **Memwright Integration** — Persistent per-session conversational memory for Bonobot agents
+  - Automatic recall before inference (injected into system prompt as `## Conversation Memory`)
+  - Automatic store after each response (user question + assistant reply)
+  - Resolves referential follow-ups: "the third one", "from the list above", "those campaigns"
+  - Per-session isolation: memories scoped to `{org_id}/{agent_id}/{session_id}`
+  - Storage: SQLite + ChromaDB (standalone, not Bonito's Postgres — evaluated for Phase 3)
+  - Pre-warms sentence-transformers model at startup to avoid first-request latency
+- **Model Tier Gating** — Memory budget scales by model capability
+  - Zero budget (no memory): flash, mini, haiku, kimi, gemma models + `auto` routing
+  - Full budget (1000 tokens): opus, sonnet, gpt-4o, and other large models
+  - Prevents small models from hallucinating on injected memory context
+- **Non-Fatal Design** — All Memwright operations wrapped in try/except
+  - Recall failure returns empty string (no memory section in prompt)
+  - Store failure is logged but does not block response delivery
+  - Async wrappers via `asyncio.to_thread` prevent blocking the event loop
+- **New file**: `backend/app/services/memwright_service.py`
+- **23 new tests**: `backend/tests/test_memwright_integration.py` covering regression, recall, store, tier gating, session isolation, and performance
+
+### Added - Org Secrets Store
+- **Secure Key-Value Storage** — Org-scoped secrets backed by HashiCorp Vault
+  - 5 API endpoints: create, list, get, update, delete
+  - 4 CLI commands: `bonito secrets list/get/set/delete`
+  - YAML support in `bonito deploy` with validation warnings
+  - Runtime injection into agent system prompts via `_resolve_secrets()`
+  - Full documentation: `docs/SECRETS.md`
+
+### Added - VectorBoost (KB Compression)
+- **Adaptive Vector Compression** — 3.9x to 8x storage reduction for knowledge base embeddings
+  - 3 compression methods: scalar-8bit (recommended), polar-8bit, polar-4bit
+  - API endpoints: GET/PUT `/api/kb/{kb_id}/config`
+  - CLI: `bonito kb config <kb> [--compression <method>]`
+  - YAML support in knowledge base declarations
+  - Research benchmarks: PolarQuant vs TurboQuant vs Lloyd-Max quantizer
+  - Full documentation: `docs/VECTORBOOST.md`
+
+### Technical Implementation
+- **Database**: Migrations 034 (org_secrets table) and 035 (agent secrets + KB compression columns)
+- **Dependencies**: Added `memwright>=0.1.0` to requirements
+- **No breaking changes**: Existing agent memory service, delegation, background tasks, and approval workflows untouched
+
 ## [2.3.0] - 2026-03-21
 
 ### Added - Documentation & Integrations

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Bonito solves this with:
 - **AI copilot** — An intelligent assistant that helps with onboarding, configuration, troubleshooting, and infrastructure-as-code generation.
 - **Multi-cloud gateway** — OpenAI-compatible API proxy with intelligent routing, automatic cross-region inference profiles (AWS Bedrock `us.` prefix handled transparently), and multi-provider failover that catches rate limits, timeouts, 5xx errors, and model unavailability to automatically route to equivalent models on other providers.
 - **Bonobot — AI Agents** — Enterprise AI agent framework with visual canvas (React Flow), project-based organization, built-in tools (KB search, HTTP requests, agent-to-agent invocation), and enterprise security (default deny, budget enforcement, rate limiting, SSRF protection, full audit trail). All agent inference routes through the Bonito gateway for cost tracking and governance.
+  - **Shared Conversational Memory (Memwright)** — Automatic per-session memory using SQLite + ChromaDB. Agents recall relevant context before inference and store conversation turns after responding. Enables referential follow-ups ("the third one", "from the list above"). Model tier gating prevents small models from hallucinating on memory context.
   - **Persistent Agent Memory** — Long-term memory system with pgvector similarity search. Agents store and retrieve facts, patterns, interactions, preferences, and contextual information across sessions. AI-powered memory extraction from conversations.
+  - **Org Secrets Store** — Secure org-scoped key-value storage backed by HashiCorp Vault. Secrets are injected into agent system prompts at runtime. Full API, CLI, and YAML deploy support.
+  - **VectorBoost (KB Compression)** — Adaptive vector compression for knowledge base embeddings. 3.9x to 8x storage reduction with 95-99.5% recall preservation. Three compression methods with API/CLI/YAML configuration.
   - **Scheduled Autonomous Execution** — Cron-based task scheduling with timezone support. Agents run tasks automatically, deliver results via webhook/email/Slack, with full execution history and retry logic.
   - **Approval Queue / Human-in-the-Loop** — Configurable approval workflows for sensitive agent actions. Risk assessment, timeout handling, auto-approval conditions, and comprehensive audit trails for enterprise compliance.
 
@@ -180,6 +183,9 @@ All 18 core phases are complete. Bonito is live at [getbonito.com](https://getbo
 - ✅ One-click model activation across all 3 clouds
 
 ### Completed (Recent)
+- ✅ **Shared Conversational Memory (Memwright)** — Automatic per-session memory for Bonobot agents. Recalls relevant context before inference, stores conversation turns after response. Model tier gating (zero memory for small/fast models). 23 tests across 6 groups.
+- ✅ **Org Secrets Store** — Secure org-scoped key-value storage backed by HashiCorp Vault. API, CLI, YAML deploy support. Runtime injection into agent system prompts.
+- ✅ **VectorBoost (KB Compression)** — Adaptive vector compression (3.9-8x reduction, 95-99.5% recall). Scalar 8-bit, Polar 8-bit, Polar 4-bit methods. API, CLI, YAML support.
 - ✅ **Auto Cross-Region Inference Profiles** — Gateway automatically detects newer Bedrock models (Claude Sonnet 4, Opus 4, Llama 3.3/4, Mistral Large 2) and routes via `us.` cross-region inference profiles. Customers register canonical model IDs; the platform handles routing transparently.
 - ✅ **Intelligent Multi-Provider Failover** — Gateway detects rate limits, timeouts, server errors (500/502/503), model unavailability, and capacity issues, then automatically retries on equivalent models across different providers (e.g. Anthropic Direct -> AWS Bedrock). Model equivalence mapping covers Claude, Llama, Mixtral, and Gemma families.
 - ✅ **SAML SSO** — Enterprise SSO with SAML 2.0 (Okta, Azure AD, Google Workspace, Custom SAML), SSO enforcement, break-glass admin, JIT provisioning
@@ -207,11 +213,15 @@ Exposes 18 tools covering providers, models, gateway, agents, knowledge bases, a
 ## Documentation
 
 - [AI Context / Knowledge Base](ROADMAP.md) — Architecture, API design, and RAG pipeline details
+- [Secrets Store](docs/SECRETS.md) — Org secrets API, CLI, YAML, and security guide
+- [VectorBoost](docs/VECTORBOOST.md) — KB compression methods, benchmarks, and configuration
+- [Bonobot Architecture](docs/BONOBOT-ARCHITECTURE.md) — Agent framework design and build plan
 - [Known Issues](docs/KNOWN-ISSUES.md) — Tracking document for known issues and fixes
 - [Pricing](docs/PRICING.md) — Plans and pricing structure
 - [SOC-2 Roadmap](docs/SOC2-ROADMAP.md) — Path to SOC-2 Type II certification
 - [SSO Scoping](docs/SSO-SCOPE.md) — SSO/SAML implementation plan
 - [Vault Production](docs/VAULT-PRODUCTION.md) — Vault hardening guide
+- [Architectural Patterns](ARCHITECTURAL_PATTERNS.md) — 7 core codebase patterns reference
 
 ---
 

--- a/backend/app/api/routes/secrets.py
+++ b/backend/app/api/routes/secrets.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.models.org_secret import OrgSecret
 from app.schemas.secret import SecretCreate, SecretUpdate, SecretListItem, SecretDetail
-from app.api.dependencies import get_current_user
+from app.api.dependencies import get_current_user, require_admin
 from app.models.user import User
 from app.core.vault import vault_client
 
@@ -33,7 +33,7 @@ def _vault_path(org_id: uuid.UUID, secret_name: str) -> str:
 async def create_secret(
     secret: SecretCreate,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(get_current_user)
+    user: User = Depends(require_admin)
 ):
     """
     Create a new org secret.
@@ -108,7 +108,7 @@ async def list_secrets(
 async def get_secret(
     name: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(get_current_user)
+    user: User = Depends(require_admin)
 ):
     """
     Get a specific secret including its value.
@@ -146,7 +146,7 @@ async def update_secret(
     name: str,
     secret: SecretUpdate,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(get_current_user)
+    user: User = Depends(require_admin)
 ):
     """
     Update an existing secret's value and/or description.
@@ -187,7 +187,7 @@ async def update_secret(
 async def delete_secret(
     name: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(get_current_user)
+    user: User = Depends(require_admin)
 ):
     """
     Delete a secret (from both Vault and Postgres).

--- a/backend/app/services/agent_engine.py
+++ b/backend/app/services/agent_engine.py
@@ -55,6 +55,7 @@ from app.services.mcp_client import MCPClientManager, make_namespaced_tool_name
 # Enterprise feature services
 from app.services.agent_memory_service import AgentMemoryService
 from app.services.agent_approval_service import AgentApprovalService
+from app.services.memwright_service import MemwrightService
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,7 @@ class AgentEngine:
         # Enterprise feature services
         self._memory_service = AgentMemoryService()
         self._approval_service = AgentApprovalService()
+        self._memwright = MemwrightService()
         
         # Security patterns for input sanitization
         self.prompt_injection_patterns = [
@@ -159,10 +161,21 @@ class AgentEngine:
             
             # 5. Agent loop (with tool execution and security)
             result = await self._run_agent_loop(agent, session, messages, tools, db, redis, audit_id)
-            
+
             # Update security metadata with input sanitization flag
             result.security.input_sanitized = input_sanitized
-            
+
+            # 5b. Store conversation turn in Memwright
+            if result.content:
+                await self._memwright.store(
+                    session_id=str(session.id),
+                    agent_id=str(agent.id),
+                    org_id=str(agent.org_id),
+                    user_msg=sanitized_message,
+                    assistant_msg=result.content,
+                    model_id=agent.model_id,
+                )
+
             # 6. Update metrics
             await self._update_metrics(agent, session, result, db)
             
@@ -384,7 +397,18 @@ class AgentEngine:
             rag_context = await self._get_rag_context(agent, user_message, db)
             if rag_context:
                 system_prompt += f"\n\n## Knowledge Context\n{rag_context}"
-        
+
+        # Inject Memwright conversational memory
+        memory_context = await self._memwright.recall(
+            session_id=str(session.id),
+            agent_id=str(agent.id),
+            org_id=str(agent.org_id),
+            message=user_message,
+            model_id=agent.model_id,
+        )
+        if memory_context:
+            system_prompt += f"\n\n## Conversation Memory\n{memory_context}"
+
         # Build message history
         messages = [{"role": "system", "content": system_prompt}]
         

--- a/backend/app/services/memwright_service.py
+++ b/backend/app/services/memwright_service.py
@@ -1,0 +1,155 @@
+"""Memwright conversational memory service for Bonito agents.
+
+Provides per-session persistent memory using Memwright (SQLite + ChromaDB).
+Designed as a lightweight, automatic memory layer that fires during agent
+execution — recall before inference, store after response.
+
+Key design decisions:
+- Direct integration (not MCP) — platform controls when to recall/store
+- Per-session isolation — different sessions never see each other's memories
+- Model tier gating — small/fast models get zero budget to prevent hallucinations
+- Non-fatal — all operations are wrapped in try/except, never blocks execution
+"""
+
+import asyncio
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+from agent_memory import AgentMemory
+
+logger = logging.getLogger(__name__)
+
+# Default data directory (can override via MEMWRIGHT_DATA_DIR env var)
+MEMWRIGHT_DATA_DIR = os.environ.get("MEMWRIGHT_DATA_DIR", "data/memwright")
+
+
+class MemwrightService:
+    """Manages per-session Memwright memory instances with model tier gating."""
+
+    # Patterns for zero-budget models (fast/small — memory would cause hallucinations)
+    ZERO_BUDGET_PATTERNS = ["flash", "mini", "kimi", "haiku", "gemma", "phi-"]
+    # Default budget for models not matching any pattern
+    DEFAULT_BUDGET = 500
+    # Full budget for large/capable models
+    FULL_BUDGET = 1000
+
+    def __init__(self):
+        self._instances: dict[str, AgentMemory] = {}
+        Path(MEMWRIGHT_DATA_DIR).mkdir(parents=True, exist_ok=True)
+        # Pre-warm sentence-transformers model at startup
+        try:
+            warmup_path = os.path.join(MEMWRIGHT_DATA_DIR, "_warmup")
+            Path(warmup_path).mkdir(parents=True, exist_ok=True)
+            warmup = AgentMemory(warmup_path)
+            warmup.recall("warmup", budget=10)
+            del warmup
+            logger.info("Memwright sentence-transformers model pre-warmed")
+        except Exception as e:
+            logger.warning(f"Memwright pre-warm failed (non-fatal): {e}")
+
+    def _get_budget(self, model_id: str) -> int:
+        """Determine memory token budget based on model tier."""
+        if not model_id or model_id == "auto":
+            return 0  # auto-routed models are typically small/flash
+        model_lower = model_id.lower()
+        for pattern in self.ZERO_BUDGET_PATTERNS:
+            if pattern in model_lower:
+                return 0
+        return self.FULL_BUDGET
+
+    def _get_instance(self, session_id: str, agent_id: str, org_id: str) -> AgentMemory:
+        """Get or create a Memwright instance for a specific session."""
+        cache_key = f"{org_id}/{agent_id}/{session_id}"
+        if cache_key not in self._instances:
+            mem_path = os.path.join(MEMWRIGHT_DATA_DIR, org_id, agent_id, session_id)
+            Path(mem_path).mkdir(parents=True, exist_ok=True)
+            self._instances[cache_key] = AgentMemory(mem_path)
+        return self._instances[cache_key]
+
+    async def recall(
+        self,
+        session_id: str,
+        agent_id: str,
+        org_id: str,
+        message: str,
+        model_id: str,
+    ) -> str:
+        """Recall relevant memories for this session. Returns formatted context string."""
+        budget = self._get_budget(model_id)
+        if budget == 0:
+            return ""
+
+        try:
+            mem = self._get_instance(session_id, agent_id, org_id)
+            results = await asyncio.to_thread(mem.recall, message, budget=budget)
+            if not results:
+                return ""
+
+            memory_lines = [r.memory.content for r in results]
+            return (
+                "[CONVERSATION MEMORY - Use this to resolve references like "
+                '"this account", "the third one", "above", "that item", etc. '
+                "This is what the user has been discussing.]\n"
+                + "\n".join(memory_lines)
+                + "\n[End of memory]"
+            )
+        except Exception as e:
+            logger.warning(f"Memwright recall error (non-fatal): {e}")
+            return ""
+
+    async def store(
+        self,
+        session_id: str,
+        agent_id: str,
+        org_id: str,
+        user_msg: str,
+        assistant_msg: str,
+        model_id: str,
+        tags: Optional[list[str]] = None,
+    ) -> None:
+        """Store a conversation turn as memory."""
+        budget = self._get_budget(model_id)
+        if budget == 0:
+            return
+
+        try:
+            mem = self._get_instance(session_id, agent_id, org_id)
+
+            # Store user question + context
+            await asyncio.to_thread(
+                mem.add,
+                f"User asked: {user_msg}",
+                tags=tags or [],
+                category="conversation",
+                confidence=0.9,
+            )
+
+            # Store assistant response (truncated to key info)
+            if assistant_msg and len(assistant_msg) > 20:
+                summary = assistant_msg[:500]
+                await asyncio.to_thread(
+                    mem.add,
+                    f"Assistant responded to '{user_msg[:100]}': {summary}",
+                    tags=tags or [],
+                    category="conversation",
+                    confidence=0.8,
+                )
+        except Exception as e:
+            logger.warning(f"Memwright store error (non-fatal): {e}")
+
+    async def clear(self, session_id: str, agent_id: str, org_id: str) -> None:
+        """Clear all memories for a session."""
+        import shutil
+
+        cache_key = f"{org_id}/{agent_id}/{session_id}"
+        self._instances.pop(cache_key, None)
+        mem_path = os.path.join(MEMWRIGHT_DATA_DIR, org_id, agent_id, session_id)
+        try:
+            if os.path.exists(mem_path):
+                await asyncio.to_thread(shutil.rmtree, mem_path)
+                logger.info(f"Cleared Memwright memory at {mem_path}")
+        except Exception as e:
+            logger.warning(f"Memwright clear error (non-fatal): {e}")

--- a/backend/railway.json
+++ b/backend/railway.json
@@ -11,5 +11,10 @@
     "healthcheckTimeout": 120,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5
-  }
+  },
+  "envVariables": {
+    "VAULT_ADDR": "http://vault:8200",
+    "MEMWRIGHT_DATA_DIR": "/data/memwright"
+  },
+  "notes": "Required Vault env vars (set in Railway dashboard, NOT in this file): VAULT_TOKEN (runtime auth), VAULT_UNSEAL_KEY (auto-unseal after first init). On first Vault deploy, check logs for the auto-generated keys printed by vault/entrypoint.sh."
 }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,3 +29,4 @@ python3-saml>=1.16.0
 xmlsec>=1.3.13
 pytz>=2024.1
 croniter>=2.0.0
+memwright>=0.1.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,4 +29,4 @@ python3-saml>=1.16.0
 xmlsec>=1.3.13
 pytz>=2024.1
 croniter>=2.0.0
-memwright>=0.1.0
+memwright>=0.1.0,<1.0.0

--- a/backend/tests/test_memwright_integration.py
+++ b/backend/tests/test_memwright_integration.py
@@ -1,0 +1,481 @@
+"""
+Tests for Memwright conversational memory integration.
+
+Covers:
+  Group 1 — Regression: existing functionality unaffected by Memwright
+  Group 2 — Memory Recall: context injection into system prompt
+  Group 3 — Memory Store: conversation turns persisted after execution
+  Group 4 — Model Tier Gating: budget enforcement by model type
+  Group 5 — Session Isolation: memories don't leak across sessions
+  Group 6 — Performance: async wrappers, non-blocking behavior
+"""
+
+import asyncio
+import os
+import shutil
+import tempfile
+import uuid
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.agent import Agent
+from app.models.agent_session import AgentSession
+from app.models.project import Project
+from app.services.memwright_service import MemwrightService
+from app.services.agent_engine import AgentEngine
+from app.schemas.bonobot import AgentRunResult, SecurityMetadata
+
+
+# ──────────────────────────────────────────────────────────────────
+# Helpers & Fixtures
+# ──────────────────────────────────────────────────────────────────
+
+def _make_llm_response(
+    content: str = "Hello from the LLM",
+    model: str = "gpt-4o",
+    prompt_tokens: int = 30,
+    completion_tokens: int = 20,
+    cost: float = 0.001,
+) -> Dict[str, Any]:
+    message = {"role": "assistant", "content": content}
+    return {
+        "choices": [{"message": message}],
+        "usage": {
+            "total_tokens": prompt_tokens + completion_tokens,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+        },
+        "cost": cost,
+        "model": model,
+    }
+
+
+def _build_mock_redis(rate_count: int = 0) -> AsyncMock:
+    mock = AsyncMock()
+    mock.ping = AsyncMock(return_value=True)
+    mock.get = AsyncMock(return_value=str(rate_count) if rate_count else None)
+    mock.incr = AsyncMock(return_value=rate_count + 1)
+    mock.expire = AsyncMock()
+    pipe = AsyncMock()
+    pipe.incr = MagicMock(return_value=pipe)
+    pipe.expire = MagicMock(return_value=pipe)
+    pipe.execute = AsyncMock(return_value=[rate_count + 1, True])
+    mock.pipeline = MagicMock(return_value=pipe)
+    mock.hset = AsyncMock()
+    mock.hgetall = AsyncMock(return_value={})
+    mock.delete = AsyncMock()
+    return mock
+
+
+@pytest_asyncio.fixture
+async def project(test_engine, test_org) -> Project:
+    factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        proj = Project(
+            org_id=test_org.id,
+            name="Memory Test Project",
+            budget_monthly=Decimal("100.00"),
+            budget_spent=Decimal("0.00"),
+        )
+        session.add(proj)
+        await session.commit()
+        await session.refresh(proj)
+        return proj
+
+
+@pytest_asyncio.fixture
+async def agent_opus(test_engine, test_org, project) -> Agent:
+    """Agent using a large model (full memory budget)."""
+    factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        a = Agent(
+            project_id=project.id,
+            org_id=test_org.id,
+            name="Opus Agent",
+            system_prompt="You are a helpful agent with memory.",
+            model_id="claude-opus-4-20250514",
+            tool_policy={"mode": "none", "allowed": [], "denied": [], "http_allowlist": []},
+            max_turns=5,
+            rate_limit_rpm=30,
+            status="active",
+        )
+        session.add(a)
+        await session.commit()
+        await session.refresh(a)
+        return a
+
+
+@pytest_asyncio.fixture
+async def agent_flash(test_engine, test_org, project) -> Agent:
+    """Agent using a small model (zero memory budget)."""
+    factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        a = Agent(
+            project_id=project.id,
+            org_id=test_org.id,
+            name="Flash Agent",
+            system_prompt="You are a fast agent.",
+            model_id="gemini-2.0-flash-001",
+            tool_policy={"mode": "none", "allowed": [], "denied": [], "http_allowlist": []},
+            max_turns=5,
+            rate_limit_rpm=30,
+            status="active",
+        )
+        session.add(a)
+        await session.commit()
+        await session.refresh(a)
+        return a
+
+
+@pytest_asyncio.fixture
+async def agent_auto(test_engine, test_org, project) -> Agent:
+    """Agent with auto model routing (zero memory budget)."""
+    factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        a = Agent(
+            project_id=project.id,
+            org_id=test_org.id,
+            name="Auto Agent",
+            system_prompt="You are a routed agent.",
+            model_id="auto",
+            tool_policy={"mode": "none", "allowed": [], "denied": [], "http_allowlist": []},
+            max_turns=5,
+            rate_limit_rpm=30,
+            status="active",
+        )
+        session.add(a)
+        await session.commit()
+        await session.refresh(a)
+        return a
+
+
+# ──────────────────────────────────────────────────────────────────
+# Group 1 — Regression Tests
+# ──────────────────────────────────────────────────────────────────
+
+class TestRegressionNoMemoryInterference:
+    """Verify existing functionality is unaffected by Memwright."""
+
+    @pytest.mark.asyncio
+    async def test_execute_basic_with_memwright_present(self, test_engine, agent_opus):
+        """Standard execution works with Memwright in the engine."""
+        factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as db:
+            engine = AgentEngine()
+            redis = _build_mock_redis()
+
+            with patch("app.services.agent_engine.gateway_chat_completion", new_callable=AsyncMock) as mock_gateway:
+                mock_gateway.return_value = _make_llm_response("Test response")
+
+                # Mock memwright to isolate this test
+                engine._memwright = AsyncMock(spec=MemwrightService)
+                engine._memwright.recall = AsyncMock(return_value="")
+                engine._memwright.store = AsyncMock()
+
+                result = await engine.execute(agent_opus, "Hello", db, redis)
+
+                assert result.content == "Test response"
+                assert result.tokens_used > 0
+
+    @pytest.mark.asyncio
+    async def test_zero_budget_model_skips_memory(self, test_engine, agent_flash):
+        """Flash/mini models should not trigger recall or store."""
+        factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as db:
+            engine = AgentEngine()
+            redis = _build_mock_redis()
+
+            with patch("app.services.agent_engine.gateway_chat_completion", new_callable=AsyncMock) as mock_gateway:
+                mock_gateway.return_value = _make_llm_response("Fast reply")
+
+                engine._memwright = AsyncMock(spec=MemwrightService)
+                engine._memwright.recall = AsyncMock(return_value="")
+                engine._memwright.store = AsyncMock()
+
+                result = await engine.execute(agent_flash, "Quick question", db, redis)
+
+                assert result.content == "Fast reply"
+                # recall and store should be called but return empty/no-op due to budget=0
+                engine._memwright.recall.assert_called_once()
+                engine._memwright.store.assert_called_once()
+
+
+# ──────────────────────────────────────────────────────────────────
+# Group 2 — Memory Recall Tests
+# ──────────────────────────────────────────────────────────────────
+
+class TestMemoryRecall:
+    """Verify memory recall is injected into system prompt."""
+
+    @pytest.mark.asyncio
+    async def test_recall_injects_into_system_prompt(self, test_engine, agent_opus):
+        """When recall returns content, it should appear in the system prompt."""
+        factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as db:
+            engine = AgentEngine()
+            redis = _build_mock_redis()
+
+            captured_messages = []
+
+            async def capture_gateway(*args, **kwargs):
+                captured_messages.extend(kwargs.get("messages", args[1] if len(args) > 1 else []))
+                return _make_llm_response("Remembered!")
+
+            with patch("app.services.agent_engine.gateway_chat_completion", new_callable=AsyncMock) as mock_gateway:
+                mock_gateway.side_effect = capture_gateway
+
+                engine._memwright = AsyncMock(spec=MemwrightService)
+                engine._memwright.recall = AsyncMock(return_value="User previously asked about RV campaigns.")
+                engine._memwright.store = AsyncMock()
+
+                result = await engine.execute(agent_opus, "What about the third one?", db, redis)
+
+                assert result.content == "Remembered!"
+                # Check system prompt contains memory context
+                system_msg = captured_messages[0]
+                assert "## Conversation Memory" in system_msg["content"]
+                assert "RV campaigns" in system_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_recall_empty_no_section(self, test_engine, agent_opus):
+        """When recall returns empty, no Conversation Memory section in prompt."""
+        factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as db:
+            engine = AgentEngine()
+            redis = _build_mock_redis()
+
+            captured_messages = []
+
+            async def capture_gateway(*args, **kwargs):
+                captured_messages.extend(kwargs.get("messages", args[1] if len(args) > 1 else []))
+                return _make_llm_response("No memory")
+
+            with patch("app.services.agent_engine.gateway_chat_completion", new_callable=AsyncMock) as mock_gateway:
+                mock_gateway.side_effect = capture_gateway
+
+                engine._memwright = AsyncMock(spec=MemwrightService)
+                engine._memwright.recall = AsyncMock(return_value="")
+                engine._memwright.store = AsyncMock()
+
+                await engine.execute(agent_opus, "Hello", db, redis)
+
+                system_msg = captured_messages[0]
+                assert "## Conversation Memory" not in system_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_recall_failure_nonfatal(self, test_engine, agent_opus):
+        """If recall throws, execute still completes successfully."""
+        factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as db:
+            engine = AgentEngine()
+            redis = _build_mock_redis()
+
+            with patch("app.services.agent_engine.gateway_chat_completion", new_callable=AsyncMock) as mock_gateway:
+                mock_gateway.return_value = _make_llm_response("Still works")
+
+                engine._memwright = AsyncMock(spec=MemwrightService)
+                engine._memwright.recall = AsyncMock(side_effect=Exception("ChromaDB exploded"))
+                engine._memwright.store = AsyncMock()
+
+                # Should NOT raise — recall failure is non-fatal
+                result = await engine.execute(agent_opus, "Hello", db, redis)
+                assert result.content == "Still works"
+
+
+# ──────────────────────────────────────────────────────────────────
+# Group 3 — Memory Store Tests
+# ──────────────────────────────────────────────────────────────────
+
+class TestMemoryStore:
+    """Verify conversation turns are stored after execution."""
+
+    @pytest.mark.asyncio
+    async def test_store_called_after_response(self, test_engine, agent_opus):
+        """Store should be called with user message and assistant response."""
+        factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as db:
+            engine = AgentEngine()
+            redis = _build_mock_redis()
+
+            with patch("app.services.agent_engine.gateway_chat_completion", new_callable=AsyncMock) as mock_gateway:
+                mock_gateway.return_value = _make_llm_response("Here are the RV campaigns")
+
+                engine._memwright = AsyncMock(spec=MemwrightService)
+                engine._memwright.recall = AsyncMock(return_value="")
+                engine._memwright.store = AsyncMock()
+
+                await engine.execute(agent_opus, "Show me RV campaigns", db, redis)
+
+                engine._memwright.store.assert_called_once()
+                call_kwargs = engine._memwright.store.call_args[1]
+                assert "RV campaigns" in call_kwargs["user_msg"]
+                assert "Here are the RV campaigns" in call_kwargs["assistant_msg"]
+
+    @pytest.mark.asyncio
+    async def test_store_not_called_when_no_content(self, test_engine, agent_opus):
+        """Store should NOT be called when result.content is empty/None."""
+        factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as db:
+            engine = AgentEngine()
+            redis = _build_mock_redis()
+
+            with patch("app.services.agent_engine.gateway_chat_completion", new_callable=AsyncMock) as mock_gateway:
+                mock_gateway.return_value = _make_llm_response(content="")
+
+                engine._memwright = AsyncMock(spec=MemwrightService)
+                engine._memwright.recall = AsyncMock(return_value="")
+                engine._memwright.store = AsyncMock()
+
+                await engine.execute(agent_opus, "Hello", db, redis)
+
+                engine._memwright.store.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_store_failure_nonfatal(self, test_engine, agent_opus):
+        """If store throws, execute still returns the result."""
+        factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as db:
+            engine = AgentEngine()
+            redis = _build_mock_redis()
+
+            with patch("app.services.agent_engine.gateway_chat_completion", new_callable=AsyncMock) as mock_gateway:
+                mock_gateway.return_value = _make_llm_response("Good response")
+
+                engine._memwright = AsyncMock(spec=MemwrightService)
+                engine._memwright.recall = AsyncMock(return_value="")
+                engine._memwright.store = AsyncMock(side_effect=Exception("Disk full"))
+
+                result = await engine.execute(agent_opus, "Hello", db, redis)
+                assert result.content == "Good response"
+
+
+# ──────────────────────────────────────────────────────────────────
+# Group 4 — Model Tier Gating Tests
+# ──────────────────────────────────────────────────────────────────
+
+class TestModelTierGating:
+    """Verify memory budget is correctly assigned by model type."""
+
+    def test_opus_gets_full_budget(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        assert svc._get_budget("claude-opus-4-20250514") == MemwrightService.FULL_BUDGET
+
+    def test_sonnet_gets_full_budget(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        assert svc._get_budget("claude-sonnet-4-20250514") == MemwrightService.FULL_BUDGET
+
+    def test_gpt4o_gets_full_budget(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        assert svc._get_budget("gpt-4o") == MemwrightService.FULL_BUDGET
+
+    def test_flash_gets_zero_budget(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        assert svc._get_budget("gemini-2.0-flash-001") == 0
+
+    def test_mini_gets_zero_budget(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        assert svc._get_budget("gpt-4o-mini") == 0
+
+    def test_kimi_gets_zero_budget(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        assert svc._get_budget("kimi-k2.5") == 0
+
+    def test_haiku_gets_zero_budget(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        assert svc._get_budget("claude-haiku-4-5-20251001") == 0
+
+    def test_auto_gets_zero_budget(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        assert svc._get_budget("auto") == 0
+
+    def test_none_gets_zero_budget(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        assert svc._get_budget("") == 0
+        assert svc._get_budget(None) == 0
+
+    def test_unknown_model_gets_default(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        assert svc._get_budget("some-future-model-v2") == MemwrightService.FULL_BUDGET
+
+
+# ──────────────────────────────────────────────────────────────────
+# Group 5 — Session Isolation Tests (unit-level)
+# ──────────────────────────────────────────────────────────────────
+
+class TestSessionIsolation:
+    """Verify memory instances are isolated per session."""
+
+    def test_different_sessions_different_instances(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        svc._instances = {}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("app.services.memwright_service.MEMWRIGHT_DATA_DIR", tmpdir):
+                inst_a = svc._get_instance("session-a", "agent-1", "org-1")
+                inst_b = svc._get_instance("session-b", "agent-1", "org-1")
+                assert inst_a is not inst_b
+
+    def test_same_session_reuses_instance(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        svc._instances = {}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("app.services.memwright_service.MEMWRIGHT_DATA_DIR", tmpdir):
+                inst_a = svc._get_instance("session-x", "agent-1", "org-1")
+                inst_b = svc._get_instance("session-x", "agent-1", "org-1")
+                assert inst_a is inst_b
+
+    def test_different_agents_different_instances(self):
+        svc = MemwrightService.__new__(MemwrightService)
+        svc._instances = {}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("app.services.memwright_service.MEMWRIGHT_DATA_DIR", tmpdir):
+                inst_a = svc._get_instance("session-1", "agent-a", "org-1")
+                inst_b = svc._get_instance("session-1", "agent-b", "org-1")
+                assert inst_a is not inst_b
+
+
+# ──────────────────────────────────────────────────────────────────
+# Group 6 — Performance Tests
+# ──────────────────────────────────────────────────────────────────
+
+class TestPerformance:
+    """Verify memory operations use async wrappers."""
+
+    @pytest.mark.asyncio
+    async def test_recall_uses_asyncio_to_thread(self):
+        """Recall should run Memwright in a thread to avoid blocking."""
+        svc = MemwrightService.__new__(MemwrightService)
+        svc._instances = {}
+
+        mock_mem = MagicMock()
+        mock_mem.recall.return_value = []
+
+        with patch.object(svc, "_get_instance", return_value=mock_mem):
+            with patch.object(svc, "_get_budget", return_value=1000):
+                with patch("app.services.memwright_service.asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+                    mock_thread.return_value = []
+                    await svc.recall("s1", "a1", "o1", "test query", "claude-opus-4-20250514")
+                    mock_thread.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_store_uses_asyncio_to_thread(self):
+        """Store should run Memwright in a thread to avoid blocking."""
+        svc = MemwrightService.__new__(MemwrightService)
+        svc._instances = {}
+
+        mock_mem = MagicMock()
+
+        with patch.object(svc, "_get_instance", return_value=mock_mem):
+            with patch.object(svc, "_get_budget", return_value=1000):
+                with patch("app.services.memwright_service.asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+                    mock_thread.return_value = None
+                    await svc.store("s1", "a1", "o1", "user msg", "assistant msg", "claude-opus-4-20250514")
+                    # Should be called twice: once for user msg, once for assistant msg
+                    assert mock_thread.call_count == 2

--- a/docs/PRICING.md
+++ b/docs/PRICING.md
@@ -39,7 +39,7 @@ For teams adopting AI across multiple providers who need visibility, routing, an
 
 ---
 
-### Enterprise — $2,000–$5,000/month (annual contract)
+### Enterprise — $10,000–$20,000/month (annual contract)
 
 For organizations that need advanced governance, compliance, and unlimited scale. Priced based on usage volume and support level.
 
@@ -59,7 +59,7 @@ For organizations that need advanced governance, compliance, and unlimited scale
 
 ---
 
-### Scale — Custom pricing (starting $50K/year)
+### Scale — Custom pricing (starting $200K/year)
 
 For large enterprises with dedicated infrastructure and compliance requirements.
 
@@ -95,4 +95,4 @@ Yes — we offer 50% off Pro for the first year for startups with <$5M in fundin
 
 ---
 
-*Pricing effective February 2026. Subject to change with 30 days notice for existing customers.*
+*Pricing effective April 2026. Subject to change with 30 days notice for existing customers.*

--- a/frontend/src/app/(marketing)/blog/posts.ts
+++ b/frontend/src/app/(marketing)/blog/posts.ts
@@ -62,7 +62,7 @@ The core value proposition is provider independence. Bonobots routes requests ac
 
 Agents can delegate to other agents, forming orchestration chains. An orchestrator agent can spin up specialist agents for code review, data analysis, or customer support, each potentially using different models optimized for their task. Everything is API-first. Customers build their own products on top of Bonito's infrastructure.
 
-**Pricing:** Free tier for experimentation, Pro at $499/month, Enterprise at $2K to $5K/month.
+**Pricing:** Free tier for experimentation, Pro at $499/month, Enterprise at $10K to $20K/month.
 
 ### OpenClaw
 
@@ -106,7 +106,7 @@ Here is how the three platforms stack up across 20 enterprise-relevant dimension
 | **Code review** | GitHub App with persona reviewers | No | No |
 | **Embeddable widget** | BonBon | No | No |
 | **Open source** | No | Yes | Yes |
-| **Pricing** | Free / $499 Pro / $2K-$5K Enterprise | Free (self-hosted + API costs) | Free (self-hosted + hardware) |
+| **Pricing** | Free / $499 Pro / $10K-$20K Enterprise | Free (self-hosted + API costs) | Free (self-hosted + hardware) |
 | **Maturity** | Production, actively shipping | Production, established community | Early preview |
 
 ## Benchmark Scenarios

--- a/frontend/src/app/(marketing)/pricing/page.tsx
+++ b/frontend/src/app/(marketing)/pricing/page.tsx
@@ -71,7 +71,7 @@ const plans = [
   },
   {
     name: "Enterprise",
-    price: "$2K–$5K",
+    price: "$10K–$20K",
     period: "/mo",
     description: "For organizations with complex AI infrastructure and governance needs.",
     features: [


### PR DESCRIPTION
## Summary

v2.5.0 merge to main. Branch was tested on , CHANGELOG entry dated 2026-04-07.

### What's included
- **Memwright** — persistent per-session conversational memory for Bonobot agents
- **Org Secrets Store** — Vault-backed org-scoped key-value secrets
- **VectorBoost** — KB embedding compression (3.9x–8x storage reduction)
- **Pricing update** — Enterprise K-K → K-K/mo, Scale K → K/yr

### Key concern
This branch has been running **ahead of main since April 7**. Production is still on . Several commits may have accumulated on main since the fork point. A breaking-change review is requested before merge.

---

_Opened by Shabot_